### PR TITLE
Use Squeak instead of unix line endings

### DIFF
--- a/packages/Liquid-Core.package/LiquidPoll.class/instance/printDataOn.withDelimiter..st
+++ b/packages/Liquid-Core.package/LiquidPoll.class/instance/printDataOn.withDelimiter..st
@@ -7,7 +7,7 @@ printDataOn: aStream withDelimiter: aDelimiter
 		do: [:aQuestion | 
 			aQuestion printOn: aStream.
 			aStream nextPutAll: aDelimiter].
-	aStream nextPut: Character linefeed.
+	aStream nextPut: Character cr.
 	self answerSets
 		do: [:answer | 
 			answer

--- a/packages/Liquid-Core.package/LiquidPoll.class/methodProperties.json
+++ b/packages/Liquid-Core.package/LiquidPoll.class/methodProperties.json
@@ -11,7 +11,7 @@
 		"open:" : "CG 5/31/2021 13:47",
 		"pollDraft" : "JS 5/25/2021 15:33",
 		"pollDraft:" : "JS 5/25/2021 15:33",
-		"printDataOn:withDelimiter:" : "psi 5/26/2021 17:27",
+		"printDataOn:withDelimiter:" : "psi 6/1/2021 13:01",
 		"startTime" : "JS 5/25/2021 15:55",
 		"startTime:" : "JS 5/25/2021 15:56",
 		"startWithId:" : "JS 5/25/2021 15:56" } }

--- a/packages/Liquid-Tests.package/LiquidPollTests.class/instance/assertString.equals..st
+++ b/packages/Liquid-Tests.package/LiquidPollTests.class/instance/assertString.equals..st
@@ -1,6 +1,0 @@
-as yet unclassified
-assertString: expected equals: actual
-| a b |
-	a := expected collect: [:char | char = Character cr ifFalse: [^char] ifTrue: [^Character lf]].
-	b := expected collect: [:char | char = Character cr ifFalse: [^char] ifTrue: [^Character lf]].
-	^ self assert: a equals: b.

--- a/packages/Liquid-Tests.package/LiquidPollTests.class/instance/testCsvPrinting.st
+++ b/packages/Liquid-Tests.package/LiquidPollTests.class/instance/testCsvPrinting.st
@@ -21,6 +21,6 @@ testCsvPrinting
 	poll addAnswer: a1; addAnswer: a2.
 	
 	view := LiquidResultsView newWithPoll: poll.
-	self assertString: view getResults equals: 'Question 1;Q2;
+	self assert: view getResults equals: 'Question 1;Q2;
 Q1A2;Q2A1;
 ;Q2A2;'.

--- a/packages/Liquid-Tests.package/LiquidPollTests.class/methodProperties.json
+++ b/packages/Liquid-Tests.package/LiquidPollTests.class/methodProperties.json
@@ -2,6 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"assertString:equals:" : "psi 5/26/2021 18:43",
 		"testClosePoll" : "CG 5/31/2021 14:01",
-		"testCsvPrinting" : "psi 5/27/2021 19:51" } }
+		"testCsvPrinting" : "psi 6/1/2021 13:01" } }


### PR DESCRIPTION
Squeak uses CR as line ending for all platforms. 
Trivia: no major OS has used this style of line endings since the 90s, Unix uses LF, Windows CRLF