### PR TITLE
Don't use streams over objectrepo

### DIFF
--- a/packages/Liquid-Core.package/LiquidPoll.class/instance/exportCSV.st
+++ b/packages/Liquid-Core.package/LiquidPoll.class/instance/exportCSV.st
@@ -1,0 +1,6 @@
+printing
+exportCSV
+	| stream |
+	stream := WriteStream on: String new.
+	self printDataOn: stream withDelimiter: ';'.
+	^ stream contents.

--- a/packages/Liquid-Core.package/LiquidPoll.class/methodProperties.json
+++ b/packages/Liquid-Core.package/LiquidPoll.class/methodProperties.json
@@ -5,6 +5,7 @@
 		"addAnswerSet:" : "NM 6/16/2021 14:35",
 		"answerSets" : "JS 5/25/2021 15:32",
 		"closeWithPassword:" : "sk 7/14/2021 10:07",
+		"exportCSV" : "sk 7/17/2021 20:43",
 		"getChoiceIdentifiers" : "NM 7/9/2021 11:27",
 		"getChoiceNames" : "NM 7/8/2021 12:37",
 		"getVotedChoicesPerChoice" : "NM 7/9/2021 11:32",

--- a/packages/Liquid-Core.package/LiquidResultsView.class/instance/getResults.st
+++ b/packages/Liquid-Core.package/LiquidResultsView.class/instance/getResults.st
@@ -1,6 +1,3 @@
 report
 getResults
-	| stream |
-	stream := WriteStream on: String new.
-	self poll printDataOn: stream withDelimiter: ';'.
-	^ stream contents
+	^ self poll exportCSV

--- a/packages/Liquid-Core.package/LiquidResultsView.class/methodProperties.json
+++ b/packages/Liquid-Core.package/LiquidResultsView.class/methodProperties.json
@@ -5,6 +5,6 @@
 	"instance" : {
 		"buildResultsTextBoxWith:" : "CG 7/4/2021 15:55",
 		"buildWith:" : "NM 7/8/2021 12:27",
-		"getResults" : "psi 5/26/2021 17:18",
+		"getResults" : "sk 7/17/2021 20:44",
 		"poll" : "NM 6/9/2021 11:49",
 		"poll:" : "psi 5/26/2021 13:46" } }


### PR DESCRIPTION
This is a last-minute fix for our big day on tuesday.

Before, `getResults` tried to use a WriteStream over the network. This is incompatible with the ObjectRepo. This PR swaps the WriteStream out for plain old strings.

Co-Authored-By: Julian Schmidt <julian.schmidt@student.hpi.de>