### PR TITLE
Fixed LQRunningPollView using the incorrect poll object for visualization

### DIFF
--- a/packages/Liquid-Core.package/LiquidRunningPollView.class/instance/closePoll.st
+++ b/packages/Liquid-Core.package/LiquidRunningPollView.class/instance/closePoll.st
@@ -1,7 +1,7 @@
 accessing
 closePoll
 	(PollRepo default
-		at: poll id
+		at: self pollId
 		ifAbsent: [^'This poll does not exist.'])
 		closeWithPassword: (LQPasswordManager default findPasswordFor: poll id ifAbsent: [ ^ UIManager default inform: 'You don''t have access to this poll.' ]).
 	(self dependents at: 1) label: 'closed Poll with ID:'. 

--- a/packages/Liquid-Core.package/LiquidRunningPollView.class/instance/visualizeResults.st
+++ b/packages/Liquid-Core.package/LiquidRunningPollView.class/instance/visualizeResults.st
@@ -1,4 +1,6 @@
 accessing
 visualizeResults
-
-	LiquidVisualizationView newWithPoll: self poll.
+	LiquidVisualizationView
+		newWithPoll: (PollRepo default
+				at: self pollId
+				ifAbsent: [^ UIManager default inform: 'This poll has already been deleted.']).

--- a/packages/Liquid-Core.package/LiquidRunningPollView.class/methodProperties.json
+++ b/packages/Liquid-Core.package/LiquidRunningPollView.class/methodProperties.json
@@ -7,8 +7,8 @@
 		"buildIDTextBoxWith:" : "RS 7/9/2021 14:21",
 		"buildWith:" : "RS 7/15/2021 14:40",
 		"changeClosePollButtonToVisualizeResultsButton" : "RS 7/15/2021 14:41",
-		"closePoll" : "RS 7/15/2021 14:53",
-		"pollId" : "RS 7/9/2021 14:04",
+		"closePoll" : "NM 7/19/2021 12:47",
 		"poll" : "RS 7/9/2021 13:54",
 		"poll:" : "RS 7/9/2021 14:04",
-		"visualizeResults" : "RS 7/15/2021 14:24" } }
+		"pollId" : "RS 7/9/2021 14:04",
+		"visualizeResults" : "NM 7/19/2021 12:51" } }

--- a/packages/Liquid-Core.package/LiquidVisualizationView.class/instance/visualizeResults.st
+++ b/packages/Liquid-Core.package/LiquidVisualizationView.class/instance/visualizeResults.st
@@ -1,3 +1,4 @@
 initialize
 visualizeResults
+	self poll answerSets ifEmpty: [^ UIManager default inform: 'No answers have been submitted yet.'].
 	(SWDiagram new visualize: self data with: SWBarChart create) openInWindowLabeled: self poll pollDraft title

--- a/packages/Liquid-Core.package/LiquidVisualizationView.class/methodProperties.json
+++ b/packages/Liquid-Core.package/LiquidVisualizationView.class/methodProperties.json
@@ -6,4 +6,4 @@
 		"poll" : "NM 6/9/2021 11:49",
 		"poll:" : "NM 7/8/2021 12:42",
 		"sortData" : "NM 7/9/2021 11:32",
-		"visualizeResults" : "NM 7/8/2021 13:48" } }
+		"visualizeResults" : "NM 7/19/2021 12:50" } }


### PR DESCRIPTION
I believe we need to include this mistake in our clean-up this week, since I believe there are other places in the code where we have a reference to a `poll`-Object in a class, where an outdated version of the poll is saved (meaning it is not updated when things on the server happen). What would probably be easiest would be to only transfer the poll-Id instead of the poll object, and have the `poll`-getter always access the ObjectRepo with the given pollId. To be discussed in #127 