### PR TITLE
developbranch load bug: fix attempt

### DIFF
--- a/packages/Liquid-UI.package/LQParticipantMenu.class/instance/messageOwnVote.st
+++ b/packages/Liquid-UI.package/LQParticipantMenu.class/instance/messageOwnVote.st
@@ -1,2 +1,4 @@
+accessing
 messageOwnVote
-	^ 'You cannot vote for yourself.'
+
+		^ 'You cannot vote for yourself.'


### PR DESCRIPTION
Cherry-picked from @RicoWro's #352. Adds the missing accessing category in messageOwnVote.st, which caused the UndefinedObject>>asSymbol crash when loading in Squeak. Together with PR #354 (methodProperties.json), this should fully resolve the bug.